### PR TITLE
fix version of ActiveRecord::Migration

### DIFF
--- a/db/migrate/011_create_stories_tasks_sprints_and_burndown.rb
+++ b/db/migrate/011_create_stories_tasks_sprints_and_burndown.rb
@@ -1,4 +1,4 @@
-class CreateStoriesTasksSprintsAndBurndown < ActiveRecord::Migration
+class CreateStoriesTasksSprintsAndBurndown < (Rails.version < 5.1) ? ActiveRecord::Migration : ActiveRecord::Migration[4.2]
   def self.up
     add_column :issues, :position, :integer
     add_column :issues, :story_points, :integer

--- a/db/migrate/012_migrate_legacy.rb
+++ b/db/migrate/012_migrate_legacy.rb
@@ -1,4 +1,4 @@
-class MigrateLegacy < ActiveRecord::Migration
+class MigrateLegacy < (Rails.version < 5.1) ? ActiveRecord::Migration : ActiveRecord::Migration[4.2]
   def self.normalize_value(v, t)
     v = v[1] if v.is_a?(Array)
 

--- a/db/migrate/015_order_tasks_using_tree.rb
+++ b/db/migrate/015_order_tasks_using_tree.rb
@@ -1,4 +1,4 @@
-class OrderTasksUsingTree < ActiveRecord::Migration
+class OrderTasksUsingTree < (Rails.version < 5.1) ? ActiveRecord::Migration : ActiveRecord::Migration[4.2]
   def self.up
     unless ActiveRecord::Base.connection.table_exists?('rb_issue_history')
       create_table :rb_issue_history do |t|

--- a/db/migrate/017_change_issue_position_column.rb
+++ b/db/migrate/017_change_issue_position_column.rb
@@ -1,4 +1,4 @@
-class ChangeIssuePositionColumn < ActiveRecord::Migration
+class ChangeIssuePositionColumn < (Rails.version < 5.1) ? ActiveRecord::Migration : ActiveRecord::Migration[4.2]
   def self.up
     change_column :issues, :position, :integer, :null => true, :default => nil
   end

--- a/db/migrate/019_add_release_tables.rb
+++ b/db/migrate/019_add_release_tables.rb
@@ -1,4 +1,4 @@
-class AddReleaseTables < ActiveRecord::Migration
+class AddReleaseTables < (Rails.version < 5.1) ? ActiveRecord::Migration : ActiveRecord::Migration[4.2]
   def self.up
     create_table :releases do |t|
       t.column :name, :string, :null => false

--- a/db/migrate/023_null_task_position.rb
+++ b/db/migrate/023_null_task_position.rb
@@ -1,6 +1,6 @@
 require 'benchmark'
 
-class NullTaskPosition < ActiveRecord::Migration
+class NullTaskPosition < (Rails.version < 5.1) ? ActiveRecord::Migration : ActiveRecord::Migration[4.2]
   def self.up
     if RbTask.tracker
       execute "update issues set position = null where tracker_id = #{RbTask.tracker}"

--- a/db/migrate/024_reinstate_remaining.rb
+++ b/db/migrate/024_reinstate_remaining.rb
@@ -1,6 +1,6 @@
 require 'benchmark'
 
-class ReinstateRemaining < ActiveRecord::Migration
+class ReinstateRemaining < (Rails.version < 5.1) ? ActiveRecord::Migration : ActiveRecord::Migration[4.2]
 
   def self.initial_estimate(issue)
     if issue.leaf?

--- a/db/migrate/025_fractional_points.rb
+++ b/db/migrate/025_fractional_points.rb
@@ -1,4 +1,4 @@
-class FractionalPoints < ActiveRecord::Migration
+class FractionalPoints < (Rails.version < 5.1) ? ActiveRecord::Migration : ActiveRecord::Migration[4.2]
   def self.up
     add_column :issues, :fractional_story_points, :float
     execute "update issues set fractional_story_points = story_points"

--- a/db/migrate/026_add_story_positions.rb
+++ b/db/migrate/026_add_story_positions.rb
@@ -1,4 +1,4 @@
-class AddStoryPositions < ActiveRecord::Migration
+class AddStoryPositions < (Rails.version < 5.1) ? ActiveRecord::Migration : ActiveRecord::Migration[4.2]
   def self.up
     # Rails doesn't support temp tables, mysql doesn't support update
     # from same-table subselect

--- a/db/migrate/027_add_index_on_issues_position.rb
+++ b/db/migrate/027_add_index_on_issues_position.rb
@@ -1,4 +1,4 @@
-class AddIndexOnIssuesPosition < ActiveRecord::Migration
+class AddIndexOnIssuesPosition < (Rails.version < 5.1) ? ActiveRecord::Migration : ActiveRecord::Migration[4.2]
   def self.up
     add_index :issues, :position 
   end

--- a/db/migrate/029_sum_remaining_hours.rb
+++ b/db/migrate/029_sum_remaining_hours.rb
@@ -1,4 +1,4 @@
-class SumRemainingHours < ActiveRecord::Migration
+class SumRemainingHours < (Rails.version < 5.1) ? ActiveRecord::Migration : ActiveRecord::Migration[4.2]
   def self.up
     unless RbStory.trackers == []
       create_table :backlogs_tmp_story_remaining_hours do |t|

--- a/db/migrate/033_unique_positions.rb
+++ b/db/migrate/033_unique_positions.rb
@@ -1,6 +1,6 @@
 require 'benchmark'
 
-class UniquePositions < ActiveRecord::Migration
+class UniquePositions < (Rails.version < 5.1) ? ActiveRecord::Migration : ActiveRecord::Migration[4.2]
   def self.up
     unless ActiveRecord::Base.connection.table_exists?('rb_issue_history')
       create_table :rb_issue_history do |t|

--- a/db/migrate/036_trust_unique_positions.rb
+++ b/db/migrate/036_trust_unique_positions.rb
@@ -1,6 +1,6 @@
 require 'benchmark'
 
-class TrustUniquePositions < ActiveRecord::Migration
+class TrustUniquePositions < (Rails.version < 5.1) ? ActiveRecord::Migration : ActiveRecord::Migration[4.2]
   def self.up
     # Needed until MySQL undoes the retardation that is http://bugs.mysql.com/bug.php?id=5573
     remove_index :issues, [:position, :position_lock]

--- a/db/migrate/037_add_rb_project_settings.rb
+++ b/db/migrate/037_add_rb_project_settings.rb
@@ -1,4 +1,4 @@
-class AddRbProjectSettings < ActiveRecord::Migration
+class AddRbProjectSettings < (Rails.version < 5.1) ? ActiveRecord::Migration : ActiveRecord::Migration[4.2]
   def self.up
     create_table :rb_project_settings do |t|
       t.references :project

--- a/db/migrate/038_rb_add_history.rb
+++ b/db/migrate/038_rb_add_history.rb
@@ -1,7 +1,7 @@
 require 'benchmark'
 require 'yaml'
 
-class RbAddHistory < ActiveRecord::Migration
+class RbAddHistory < (Rails.version < 5.1) ? ActiveRecord::Migration : ActiveRecord::Migration[4.2]
   def self.up
     #drop_table :rb_journals if ActiveRecord::Base.connection.table_exists?('rb_journals')
 

--- a/db/migrate/039_add_show_in_scrum_stats_project_setting.rb
+++ b/db/migrate/039_add_show_in_scrum_stats_project_setting.rb
@@ -1,4 +1,4 @@
-class AddShowInScrumStatsProjectSetting < ActiveRecord::Migration
+class AddShowInScrumStatsProjectSetting < (Rails.version < 5.1) ? ActiveRecord::Migration : ActiveRecord::Migration[4.2]
   def self.up
     add_column :rb_project_settings, :show_in_scrum_stats, :boolean, {:default => true, :null => false}
   end

--- a/db/migrate/040_add_release_id_to_issues.rb
+++ b/db/migrate/040_add_release_id_to_issues.rb
@@ -1,4 +1,4 @@
-class AddReleaseIdToIssues < ActiveRecord::Migration
+class AddReleaseIdToIssues < (Rails.version < 5.1) ? ActiveRecord::Migration : ActiveRecord::Migration[4.2]
   def self.up
     unless ActiveRecord::Base.connection.column_exists?(:issues, :release_id)
       add_column :issues, :release_id, :integer

--- a/db/migrate/041_add_sharing_to_releases.rb
+++ b/db/migrate/041_add_sharing_to_releases.rb
@@ -1,4 +1,4 @@
-class AddSharingToReleases < ActiveRecord::Migration
+class AddSharingToReleases < (Rails.version < 5.1) ? ActiveRecord::Migration : ActiveRecord::Migration[4.2]
   def self.up
     add_column :releases, :sharing, :string, :default => 'none', :null => false
     add_index :releases, :sharing

--- a/db/migrate/042_migrate_releases.rb
+++ b/db/migrate/042_migrate_releases.rb
@@ -1,4 +1,4 @@
-class MigrateReleases < ActiveRecord::Migration
+class MigrateReleases < (Rails.version < 5.1) ? ActiveRecord::Migration : ActiveRecord::Migration[4.2]
   def self.up
     add_column :releases, :status, :string, :null => false, :default => 'open'
     add_column :releases, :description, :text

--- a/db/migrate/043_add_releases_planned_velocity.rb
+++ b/db/migrate/043_add_releases_planned_velocity.rb
@@ -1,4 +1,4 @@
-class AddReleasesPlannedVelocity < ActiveRecord::Migration
+class AddReleasesPlannedVelocity < (Rails.version < 5.1) ? ActiveRecord::Migration : ActiveRecord::Migration[4.2]
   def self.up
     add_column :releases, :planned_velocity, :float
   end

--- a/db/migrate/044_add_release_relationship_to_issues.rb
+++ b/db/migrate/044_add_release_relationship_to_issues.rb
@@ -1,4 +1,4 @@
-class AddReleaseRelationshipToIssues < ActiveRecord::Migration
+class AddReleaseRelationshipToIssues < (Rails.version < 5.1) ? ActiveRecord::Migration : ActiveRecord::Migration[4.2]
   def self.up
       add_column :issues, :release_relationship, :string, :default => 'auto', :null => false
   end

--- a/db/migrate/045_drop_release_burndown_days.rb
+++ b/db/migrate/045_drop_release_burndown_days.rb
@@ -1,4 +1,4 @@
-class DropReleaseBurndownDays < ActiveRecord::Migration
+class DropReleaseBurndownDays < (Rails.version < 5.1) ? ActiveRecord::Migration : ActiveRecord::Migration[4.2]
   def self.up
     if ActiveRecord::Base.connection.table_exists?('release_burndown_days')
       drop_table :release_burndown_days

--- a/db/migrate/046_add_releases_indexes.rb
+++ b/db/migrate/046_add_releases_indexes.rb
@@ -1,4 +1,4 @@
-class AddReleasesIndexes < ActiveRecord::Migration
+class AddReleasesIndexes < (Rails.version < 5.1) ? ActiveRecord::Migration : ActiveRecord::Migration[4.2]
   def self.up
     add_index :issues, :release_id
     add_index :issues, :release_relationship

--- a/db/migrate/047_add_issues_rbcache.rb
+++ b/db/migrate/047_add_issues_rbcache.rb
@@ -1,4 +1,4 @@
-class AddIssuesRbcache < ActiveRecord::Migration
+class AddIssuesRbcache < (Rails.version < 5.1) ? ActiveRecord::Migration : ActiveRecord::Migration[4.2]
   def self.up
     create_table :rb_release_burndown_caches do |t|
       t.column :issue_id, :integer, :null => false

--- a/db/migrate/048_add_issues_release_day_cache.rb
+++ b/db/migrate/048_add_issues_release_day_cache.rb
@@ -1,6 +1,6 @@
 require "./plugins/redmine_backlogs/db/migrate/047_add_issues_rbcache.rb"
 
-class AddIssuesReleaseDayCache < ActiveRecord::Migration
+class AddIssuesReleaseDayCache < (Rails.version < 5.1) ? ActiveRecord::Migration : ActiveRecord::Migration[4.2]
   def self.up
     create_table :rb_release_burnchart_day_caches, :id => false do |t|
       t.column :issue_id, :integer, :null => false

--- a/db/migrate/049_add_release_multiview.rb
+++ b/db/migrate/049_add_release_multiview.rb
@@ -1,4 +1,4 @@
-class AddReleaseMultiview < ActiveRecord::Migration
+class AddReleaseMultiview < (Rails.version < 5.1) ? ActiveRecord::Migration : ActiveRecord::Migration[4.2]
   def self.up
     create_table :rb_releases_multiview do |t|
       t.column :name, :string, :null => false


### PR DESCRIPTION
This fix specifies which version of ActiveRecord::Migration to inherit from.

From rails version 5.1, db migration fails with following error:
 Directly inheriting from ActiveRecord::Migration is not supported. Please specify the Rails release the migration was written for:
 class CreateStoriesTasksSprintsAndBurndown < ActiveRecord::Migration[4.2]
 Caused by:
 StandardError: Directly inheriting from ActiveRecord::Migration is not supported. Please specify the Rails release the migration was written for: