### PR TITLE
[BUGFixed] Cant drag items from Product Backlog

### DIFF
--- a/assets/javascripts/backlog.js
+++ b/assets/javascripts/backlog.js
@@ -194,7 +194,7 @@ RB.Backlog = RB.Object.create({
       ui.item.addClass("dragging");
     } else {
       // for IE    
-      ui.item.draggable('enabled');
+      ui.item.draggable();
     }
     ui.item.data('dragging', 'true');
   },


### PR DESCRIPTION
In redmine 4.1.0, Backlog tab, we can't drag items, the javascript error was shown in console (tested in chrome and firefox).

jquery-2.2.4-ui-1.11.0-ujs-5.2.3.js?1576844386:2 Uncaught Error: cannot call methods on draggable prior to initialization; attempted to call method 'enabled'
    at Function.error (jquery-2.2.4-ui-1.11.0-ujs-5.2.3.js?1576844386:2)
    at HTMLLIElement.<anonymous> (jquery-2.2.4-ui-1.11.0-ujs-5.2.3.js?1576844386:14)
    at Function.each (jquery-2.2.4-ui-1.11.0-ujs-5.2.3.js?1576844386:2)
    at jQuery.fn.init.each (jquery-2.2.4-ui-1.11.0-ujs-5.2.3.js?1576844386:2)
    at jQuery.fn.init.e.fn.<computed> [as draggable] (jquery-2.2.4-ui-1.11.0-ujs-5.2.3.js?1576844386:14)
    at HTMLUListElement.dragStart (backlog.js?1578612524:198)
    at e.<computed>.<computed>._trigger (jquery-2.2.4-ui-1.11.0-ujs-5.2.3.js?1576844386:14)
    at e.<computed>.<computed>._trigger (jquery-2.2.4-ui-1.11.0-ujs-5.2.3.js?1576844386:20)
    at e.<computed>.<computed>._trigger (jquery-2.2.4-ui-1.11.0-ujs-5.2.3.js?1576844386:14)
    at e.<computed>.<computed>._mouseStart (jquery-2.2.4-ui-1.11.0-ujs-5.2.3.js?1576844386:19)