### PR TITLE
Reenable release burndowns

### DIFF
--- a/app/controllers/rb_releases_multiview_controller.rb
+++ b/app/controllers/rb_releases_multiview_controller.rb
@@ -19,7 +19,7 @@ class RbReleasesMultiviewController < RbApplicationController
     if request.post?
       # Convert id's into numbers and remove blank
       params[:release_multiview][:release_ids]=selected_ids(params[:release_multiview][:release_ids])
-      @release_multiview.attributes = params[:release_multiview]
+      @release_multiview.attributes = release_multiview_params
 
       if @release_multiview.save
         flash[:notice] = l(:notice_successful_create)
@@ -34,7 +34,7 @@ class RbReleasesMultiviewController < RbApplicationController
       # Convert id's into numbers and remove blank
       params[:release_multiview][:release_ids]=selected_ids(params[:release_multiview][:release_ids])
 
-      if @release_multiview.update_attributes(params[:release_multiview])
+      if @release_multiview.update_attributes(release_multiview_params)
         flash[:notice] = l(:notice_successful_update)
         redirect_to :controller => 'rb_releases_multiview', :action => 'show', :release_multiview_id => @release_multiview
       end
@@ -47,6 +47,11 @@ class RbReleasesMultiviewController < RbApplicationController
   def destroy
     @release_multiview.destroy
     redirect_to :controller => 'rb_releases', :action => 'index', :project_id => @project
+  end
+
+private
+  def release_multiview_params
+	params.require(:release_multiview).permit(:name, :description, :release_ids => [])
   end
 
 end

--- a/app/models/rb_release.rb
+++ b/app/models/rb_release.rb
@@ -256,8 +256,7 @@ class RbRelease < ActiveRecord::Base
   end
 
   def has_burndown?
-    false #FIXME release burndown broken
-    #return self.stories.size > 0
+    return self.stories.size > 0
   end
 
   def burndown

--- a/app/models/rb_release_multiview.rb
+++ b/app/models/rb_release_multiview.rb
@@ -2,11 +2,11 @@ class RbReleaseMultiview < ActiveRecord::Base
   self.table_name = 'rb_releases_multiview'
 
   #unloadable
-  #attr_protected :created_at # hack, all attributes will be mass asigment
+  # attr_protected :created_at # hack, all attributes will be mass asigment
 
   belongs_to :project
 
-  #attr_accessible :name, :project_id, :release_ids, :project, :description
+  # attr_accessible :name, :project_id, :release_ids, :project, :description
   serialize :release_ids
 
   validates_presence_of :project_id, :name
@@ -19,15 +19,13 @@ class RbReleaseMultiview < ActiveRecord::Base
   end
 
   def has_burnchart?
-    false #FIXME release burndown broken
-    #releases.inject(false) {|result,release| result |= release.has_burndown?}
+    releases.inject(false) {|result,release| result |= release.has_burndown?}
   end
 
   def burnchart
-    return nil #FIXME release burndown broken
-    #return nil unless self.has_burnchart?
-    #@cached_burnchart ||= RbReleaseMultiviewBurnchart.new(self)
-    #return @cached_burnchart
+    return nil unless self.has_burnchart?
+    @cached_burnchart ||= RbReleaseMultiviewBurnchart.new(self)
+    return @cached_burnchart
   end
 
 end

--- a/app/models/rb_stacked_data.rb
+++ b/app/models/rb_stacked_data.rb
@@ -86,7 +86,7 @@ private
   # Calculate estimated end dates for all stacked series trendlines crossing closed series trendline
   def calculate_estimate_end_days
     @total_estimates.each{|k,l|
-      @total_estimates[k][:end_date_estimate] = l[:trendline].crossing_date(@closed_estimate)
+      @total_estimates[k][:end_date_estimate] = l[:trendline].crossing_date(@closed_estimate) unless @closed_estimate.nil?
     }
   end
 


### PR DESCRIPTION
Re-enables release burndowns

They appear to have been disabled a long time ago, due to being broken, but I could only find minor issues.

Your fork seems the most up-to-date, while not including breaking changes, so I'm opening a pull request for you, in case you want it.